### PR TITLE
feature(STEP17): Kafka 메세지 발행

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ dependencyManagement {
 
 dependencies {
     implementation(libs.spring.boot.starter.web)
+    testImplementation (libs.lombok)
+    testAnnotationProcessor(libs.lombok)
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
     annotationProcessor(libs.spring.boot.configuration.processor)
@@ -31,6 +33,7 @@ dependencies {
     implementation ("org.springframework.boot:spring-boot-starter-jdbc")
     runtimeOnly ("com.h2database:h2")
     implementation ("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+    testImplementation ("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1")
     implementation ("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1")
 
     // 낙관락 - 재시도
@@ -42,6 +45,17 @@ dependencies {
     implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0")
 
     runtimeOnly ("com.mysql:mysql-connector-j")
+
+    // testcontainer
+    testImplementation ("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation ("org.testcontainers:testcontainers:1.20.3")
+    testImplementation ("org.testcontainers:junit-jupiter:1.20.3")
+    testImplementation ("org.testcontainers:mysql:1.20.3")
+
+    // Kafka
+    implementation ("org.springframework.kafka:spring-kafka")
+    testImplementation("org.testcontainers:kafka:1.17.6")
+    testImplementation ("org.awaitility:awaitility:4.2.0")
 }
 
 // about source and compilation

--- a/src/main/java/io/hhplus/concert/app/infra/provider/kafka/ConcertKafkaProvider.java
+++ b/src/main/java/io/hhplus/concert/app/infra/provider/kafka/ConcertKafkaProvider.java
@@ -1,0 +1,27 @@
+package io.hhplus.concert.app.infra.provider.kafka;
+
+import io.hhplus.concert.app.application.concert.ConcertEventPublisher;
+import io.hhplus.concert.app.domain.concert.Reservation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertKafkaProvider implements ConcertEventPublisher {
+
+    private final KafkaTemplate<String, Reservation> kafkaTemplate;
+
+    @Value("${spring.kafka.topic.reservation}")
+    private String reservationTopic;
+
+    @Override
+    public void successReservation( Reservation reservation ) {
+        kafkaTemplate.send( reservationTopic, reservation );
+    }
+}

--- a/src/main/java/io/hhplus/concert/app/interfaces/consumer/kafka/ConcertKafkaConsumer.java
+++ b/src/main/java/io/hhplus/concert/app/interfaces/consumer/kafka/ConcertKafkaConsumer.java
@@ -1,0 +1,27 @@
+package io.hhplus.concert.app.interfaces.consumer.kafka;
+
+import io.hhplus.concert.app.application.concert.ConcertEventListener;
+import io.hhplus.concert.app.domain.concert.Reservation;
+import jdk.jfr.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ConcertKafkaConsumer implements ConcertEventListener<Event> {
+
+    @Override
+    @KafkaListener(topics = "${spring.kafka.topic.reservation}", groupId = "${spring.kafka.consumer.reservation.group-id}")
+    public void successReservationHandler(@Payload Reservation reservation) throws InterruptedException {
+
+        log.info("Kafka ::::: Reservation {} success!", reservation.getId());
+        Thread.sleep(5000);
+        log.info("Kafka ::::: ReservationEventHandler End");
+    }
+}

--- a/src/main/java/io/hhplus/concert/config/KafkaConfig.java
+++ b/src/main/java/io/hhplus/concert/config/KafkaConfig.java
@@ -1,0 +1,66 @@
+package io.hhplus.concert.config;
+
+import io.hhplus.concert.app.domain.concert.Reservation;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.server}")
+    private String server;
+
+
+    @Value("${spring.kafka.consumer.reservation.group-id}")
+    private String reservationGroupId;
+
+    @Bean
+    public KafkaTemplate<String, Reservation> kafkaTemplate() {
+
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, server);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "io.hhplus.concert.app.domain.concert");
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(configProps));
+    }
+
+    @Bean
+    public ConsumerFactory<String, Reservation> consumerFactory() {
+
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, server);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, reservationGroupId);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "io.hhplus.concert.app.domain.concert");
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Reservation> kafkaListenerContainerFactory() {
+
+        ConcurrentKafkaListenerContainerFactory<String, Reservation> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,30 +1,22 @@
 spring:
-  application.name: hhp-clean-architecture
-
-  h2:
-    console:
-      enabled: true  # H2 콘솔을 사용할 수 있게 설정
-      path: /h2-console
-
-  datasource:
-#    driver-class-name: com.mysql.cj.jdbc.Driver
-#    url: jdbc:mysql://localhost:3306/hhp
-
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb  # 'testdb'는 원하는 이름으로 설정 가능
-#    url: jdbc:h2:tcp://localhost/~/test
-    username: sa
-    password:
+#  config:
+#    activate:
+#      on-profile: test
 
   jpa:
     hibernate:
-      ddl-auto: create  # 스키마 자동 업데이트
-#      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-        show_sql: true # SQL 쿼리 출력 여부
-        format_sql: true # SQL 쿼리 포맷팅 여부
+        jdbc:
+          lob:
+            non_contextual_creation: true
+        dialects: org.hibernate.dialect.MySQL57Dialect
+        format_sql: true
+    database: mysql
+    generate-ddl: true
+    open-in-view: false
+    show-sql: true
     defer-datasource-initialization: true # 데이터 베이스 초기화 시점을 지연
 
   sql:
@@ -38,13 +30,21 @@ spring:
       host: localhost
       port: 6379
 
-springdoc:
-  api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui.html
+  kafka:
+    server: localhost:9092
+    topic:
+      reservation: reservation_success
+    consumer:
+      auto-offset-reset: earliest
+      reservation:
+        group-id: reservation_consumer
 
-  p6spy:
-    logLevel: DEBUG
-    log: com.p6spy.engine.spy.appender.Slf4JLogger
-    appender: com.p6spy.engine.spy.appender.Slf4JLogger
+logging:
+  level:
+    root: ERROR
+    io:
+      hhplus:
+        concert:
+          app:
+            infra:
+              spring: INFO # 해당 패키지로 지정

--- a/src/main/resources/application.yml.old
+++ b/src/main/resources/application.yml.old
@@ -1,0 +1,50 @@
+spring:
+  application.name: hhp-clean-architecture
+
+  h2:
+    console:
+      enabled: true  # H2 콘솔을 사용할 수 있게 설정
+      path: /h2-console
+
+  datasource:
+#    driver-class-name: com.mysql.cj.jdbc.Driver
+#    url: jdbc:mysql://localhost:3306/hhp
+
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb  # 'testdb'는 원하는 이름으로 설정 가능
+#    url: jdbc:h2:tcp://localhost/~/test
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create  # 스키마 자동 업데이트
+#      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        show_sql: true # SQL 쿼리 출력 여부
+        format_sql: true # SQL 쿼리 포맷팅 여부
+    defer-datasource-initialization: true # 데이터 베이스 초기화 시점을 지연
+
+  sql:
+    init:
+      mode: always
+      continue-on-error: true
+      data-locations: classpath:sql/data.sql
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+
+  p6spy:
+    logLevel: DEBUG
+    log: com.p6spy.engine.spy.appender.Slf4JLogger
+    appender: com.p6spy.engine.spy.appender.Slf4JLogger

--- a/src/test/java/io/hhplus/concert/app/application/concert/ConcertReserveKafkaTest.java
+++ b/src/test/java/io/hhplus/concert/app/application/concert/ConcertReserveKafkaTest.java
@@ -1,0 +1,58 @@
+package io.hhplus.concert.app.application.concert;
+
+import io.hhplus.concert.app.config.TestContainerSupport;
+import io.hhplus.concert.app.domain.concert.*;
+import io.hhplus.concert.app.interfaces.consumer.kafka.ConcertKafkaConsumer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.time.Duration;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("카프카 콘서트 예약 통합 테스트")
+@SpringBootTest
+class ConcertReserveKafkaTest extends TestContainerSupport {
+
+    @Autowired
+    private ConcertUsecase concertUseCase;
+
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    @SpyBean
+    private ConcertKafkaConsumer concertEventListener;
+
+    @Test
+    void 좌석_예약_및_결제() throws InterruptedException {
+
+        long userId = 1L;
+        long concertItemId = 1L;
+        long seatId = 1L;
+
+        // 가예약 생성 및 결제
+        Reservation reserved = concertUseCase.reserveSeatAndPay(userId, concertItemId, seatId);
+
+        // 카프카가 소비하고 DB 상태가 변경될 때까지 기다림
+        await()
+                .pollInterval(Duration.ofSeconds(3))
+                .atMost(10, SECONDS)
+                .untilAsserted(() -> {
+
+                    verify(concertEventListener, times(1)).successReservationHandler(any(Reservation.class));
+                    Reservation reservation = concertRepository.findReservationByUserId(userId);
+                    assertNotNull(reservation, "예약이 생성되지 않았습니다.");
+                    assertEquals(ReservationStatus.CONFIRMED, reservation.getStatus(), "예약이 확인되었습니다.");
+        });
+    }
+
+
+}

--- a/src/test/java/io/hhplus/concert/app/application/concert/ConcertUsecaseIntegrationTest.java
+++ b/src/test/java/io/hhplus/concert/app/application/concert/ConcertUsecaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.hhplus.concert.app.application.concert;
 
+import io.hhplus.concert.app.config.TestContainerSupport;
 import io.hhplus.concert.app.domain.concert.*;
 import io.hhplus.concert.app.interfaces.consumer.event.ConcertSpringEventListener;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.verify;
 @DisplayName("콘서트 예약 통합테스트")
 @SpringBootTest
 @Transactional
-class ConcertUsecaseIntegrationTest {
+class ConcertUsecaseIntegrationTest extends TestContainerSupport {
 
     @Autowired
     private ConcertUsecase concertUseCase;

--- a/src/test/java/io/hhplus/concert/app/config/TestContainerSupport.java
+++ b/src/test/java/io/hhplus/concert/app/config/TestContainerSupport.java
@@ -1,0 +1,72 @@
+package io.hhplus.concert.app.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@Slf4j
+@ActiveProfiles("test")
+@EnableAsync
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class TestContainerSupport {
+
+    private static final JdbcDatabaseContainer MYSQL = new MySQLContainer("mysql:8");
+
+    private static final GenericContainer REDIS = new GenericContainer("redis:6.2.6").withExposedPorts(6379);
+
+    private static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @BeforeAll
+    public static void startContainers() {
+        log.info("Starting containers...");
+        MYSQL.start();
+        REDIS.start();
+        KAFKA_CONTAINER.start();
+        log.info("Containers started successfully.");
+    }
+
+    @AfterAll
+    public static void stopContainers() {
+        log.info("Stopping containers...");
+        MYSQL.stop();
+        REDIS.stop();
+        log.info("Containers stopped successfully.");
+    }
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        // mysql
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.~username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+
+        // redis
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+
+        // kafka
+        registry.add("spring.kafka.bootstrap-servers", KAFKA_CONTAINER::getBootstrapServers);
+    }
+
+    static {
+        MYSQL.waitingFor(Wait.forListeningPort());
+        REDIS.waitingFor(Wait.forListeningPort());
+        KAFKA_CONTAINER.waitingFor(Wait.forListeningPort());
+    }
+}


### PR DESCRIPTION
### **`STEP 17_기본`**
- docker 를 이용해 kafka 를 설치 및 실행하고 애플리케이션과 연결
- 각 프레임워크 (nest.js, spring) 에 적합하게 카프카 consumer, producer 를 연동 및 테스트
- 기존에 애플리케이션 이벤트를 카프카 메세지 발행으로 변경